### PR TITLE
修复Vercel版本邮件不发送的问题

### DIFF
--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -1018,6 +1018,10 @@ async function noticePushPlus (comment) {
 
 // 自定义WeCom企业微信api通知
 async function noticeWeComPush (comment) {
+  if (!config.WECOM_API_URL) {
+    console.log('未配置 WECOM_API_URL,跳过企业微信推送')
+    return
+  }
   if (config.BLOGGER_EMAIL === comment.mail) return
   const SITE_URL = config.SITE_URL
   const WeComContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)


### PR DESCRIPTION
遇到的问题见 #226 

改动如下：
1. Vercel版本中发送邮件时调用了自身，设置300ms的timeout会导致axios超时而报错，所以移除了超时设置。
2. nodemailer与Vercel好像存在兼容问题，根据[这个贴子](https://stackoverflow.com/questions/65631481/nodemailer-in-vercel-not-sending-email-in-production)使用Promise套了一层。
3. 企业微信通知的环境变量未设置时没有判断，导致没有设置时也会向下执行，进而导致axios报错，所以加上了判断。