### PR TITLE
使用VERCEL_URL域名来发送调用自身请求

### DIFF
--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -842,12 +842,12 @@ async function commentSubmit (event) {
   // 异步垃圾检测、发送评论通知
   try {
     console.log('开始异步垃圾检测、发送评论通知')
-    await axios.post(`${request.headers['x-forwarded-proto']}://${request.headers.host}`, {
+    await axios.post(`https://${process.env.VERCEL_URL}`, {
       event: 'POST_SUBMIT',
       comment
     }, { headers: { 'x-twikoo-recursion': 'true' }, timeout: 300 }) // 设置较短的 timeout 来实现异步
   } catch (e) {
-    console.log('请求失败:', e.message)
+    console.log('已经发送POST_SUBMIT请求,等待响应')
   }
   return res
 }

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -841,12 +841,13 @@ async function commentSubmit (event) {
   res.id = comment.id
   // 异步垃圾检测、发送评论通知
   try {
+    console.log('开始异步垃圾检测、发送评论通知')
     await axios.post(`${request.headers['x-forwarded-proto']}://${request.headers.host}`, {
       event: 'POST_SUBMIT',
       comment
     }, { headers: { 'x-twikoo-recursion': 'true' }, timeout: 300 }) // 设置较短的 timeout 来实现异步
   } catch (e) {
-    console.log('开始异步垃圾检测、发送评论通知')
+    console.log('请求失败:', e.message)
   }
   return res
 }


### PR DESCRIPTION
今天发现又发送不了邮件通知了，摸索中发现了一个可能存在的问题：
由于我在Vercel给Twikoo配置了自定义域名，可能由于这个自定义域名的DNS在国内或者是其他原因，导致Vercel通过我的域名发送请求时经常发送不出去（具体原因仍然正在排查）

不过为了解决此问题，我想到Vercel有内置的`VERCEL_URL`环境变量，使用这个域名发送请求的话成功率必定要大的多，所以就把`POST_SUBMIT`的请求域名换成了从环境变量中获取，经测试没有任何问题。