### PR TITLE
fix: 🐛[bug] Comment length out of the preview box

### DIFF
--- a/src/view/components/TkSubmit.vue
+++ b/src/view/components/TkSubmit.vue
@@ -393,5 +393,6 @@ export default {
   padding: 5px 15px;
   border: 1px solid rgba(128,128,128,0.31);
   border-radius: 4px;
+  word-break: break-word;
 }
 </style>


### PR DESCRIPTION
评论内容预览超出了预览框
回复评论的评论框没有问题，因为`.tk-comment`有`word-break: break-all;`

如下图所示
![image](https://user-images.githubusercontent.com/48512251/133749828-b959a467-2d44-4e2f-846e-cc9896ae3fb4.png)

