### PR TITLE
添加钉钉WebHook消息推送

### DIFF
--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -1039,7 +1039,7 @@ async function noticeWeComPush (comment) {
 
 // 自定义钉钉WebHook通知
 async function noticeDingTalkHook (comment) {
-  if (!config.DingTalk_WebHook) {
+  if (!config.DingTalk_WebHook_URL) {
     console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
     return
   }
@@ -1048,8 +1048,8 @@ async function noticeDingTalkHook (comment) {
   const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
   const DingTalkApiContent = encodeURIComponent(DingTalkContent)
   const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
-  const DingTalkApiUrl = config.DingTalk_WebHook
-  const sendResult = await axios.post(DingTalkApiUrl , DingTalkPostBody)
+  const DingTalkApiUrl = config.DingTalk_WebHook_URL
+  const sendResult = await axios.post(DingTalkApiUrl, DingTalkPostBody)
   console.log('钉钉WebHook 通知结果：', sendResult)
 }
 

--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -1040,16 +1040,12 @@ async function noticeWeComPush (comment) {
 // 自定义钉钉WebHook通知
 async function noticeDingTalkHook (comment) {
   if (!config.DingTalk_WebHook_URL) {
-    console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
+    console.log('没有配置 DingTalk_WebHook，放弃钉钉WebHook推送')
     return
   }
   if (config.BLOGGER_EMAIL === comment.mail) return
-  const SITE_URL = config.SITE_URL
-  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
-  const DingTalkApiContent = encodeURIComponent(DingTalkContent)
-  const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
-  const DingTalkApiUrl = config.DingTalk_WebHook_URL
-  const sendResult = await axios.post(DingTalkApiUrl, DingTalkPostBody)
+  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + ' 说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || config.SITE_URL + comment.url, comment.id)
+  const sendResult = await axios.post(config.DingTalk_WebHook_URL, { msgtype: 'text', text: { content: DingTalkContent } })
   console.log('钉钉WebHook 通知结果：', sendResult)
 }
 

--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -930,7 +930,8 @@ async function noticeMaster (comment) {
     'SC_SENDKEY',
     'QM_SENDKEY',
     'PUSH_PLUS_TOKEN',
-    'WECOM_API_URL'
+    'WECOM_API_URL',
+    'DingTalk_WebHook_URL'
   ]
   // 判断是否存在即时消息推送配置
   const hasIMPushConfig = IM_PUSH_CONFIGS.some(item => !!config[item])
@@ -1046,8 +1047,9 @@ async function noticeDingTalkHook (comment) {
   const SITE_URL = config.SITE_URL
   const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
   const DingTalkApiContent = encodeURIComponent(DingTalkContent)
+  const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
   const DingTalkApiUrl = config.DingTalk_WebHook
-  const sendResult = await axios.get(DingTalkApiUrl + DingTalkApiContent)
+  const sendResult = await axios.post(DingTalkApiUrl , DingTalkPostBody)
   console.log('钉钉WebHook 通知结果：', sendResult)
 }
 

--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -879,6 +879,7 @@ async function sendNotice (comment) {
     noticeWeChat(comment),
     noticePushPlus(comment),
     noticeWeComPush(comment),
+    noticeDingTalkHook(comment),
     noticeQQ(comment)
   ]).catch(err => {
     console.error('邮件通知异常：', err)
@@ -1033,6 +1034,21 @@ async function noticeWeComPush (comment) {
   const WeComApiUrl = config.WECOM_API_URL
   const sendResult = await axios.get(WeComApiUrl + WeComApiContent)
   console.log('WinxinPush 通知结果：', sendResult)
+}
+
+// 自定义钉钉WebHook通知
+async function noticeDingTalkHook (comment) {
+  if (!config.DingTalk_WebHook) {
+    console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
+    return
+  }
+  if (config.BLOGGER_EMAIL === comment.mail) return
+  const SITE_URL = config.SITE_URL
+  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
+  const DingTalkApiContent = encodeURIComponent(DingTalkContent)
+  const DingTalkApiUrl = config.DingTalk_WebHook
+  const sendResult = await axios.get(DingTalkApiUrl + DingTalkApiContent)
+  console.log('钉钉WebHook 通知结果：', sendResult)
 }
 
 // QQ通知

--- a/src/js/utils/i18n/i18n.js
+++ b/src/js/utils/i18n/i18n.js
@@ -370,10 +370,10 @@ export default {
     'Self-built enterprise WeChat notification API interface URL, free unlimited, refer to the tutorial: https://guole.fun/posts/626/'
   ],
   [S.ACI + '_DingTalk_WebHook_URL']: [
-    '钉钉 WebHook API 接口 URL，参考教程：',
-    '钉钉 WebHooK API 接口 URL，參考教程：',
-    '钉钉 API 接口 URL，參考教程：',
-    'DingTalk Webhook API interface URL, refer to the tutorial: '
+    '钉钉 WebHook API 接口 URL，参考教程：https://blog.ljcbaby.top/article/Twikoo-DingTalk/',
+    '钉钉 WebHooK API 接口 URL，參考教程：https://blog.ljcbaby.top/article/Twikoo-DingTalk/',
+    '钉钉 WebHooK API 接口 URL，參考教程：https://blog.ljcbaby.top/article/Twikoo-DingTalk/',
+    'DingTalk Webhook API interface URL, refer to the tutorial (Chiinese Only): https://blog.ljcbaby.top/article/Twikoo-DingTalk/ '
   ],
   [S.ACI + '_SENDER_EMAIL']: [
     '邮件通知邮箱地址。对于大多数邮箱服务商，SENDER_EMAIL 必须和 SMTP_USER 保持一致，否则无法发送邮件。',

--- a/src/js/utils/i18n/i18n.js
+++ b/src/js/utils/i18n/i18n.js
@@ -363,6 +363,12 @@ export default {
     '自行搭建的企業微信通知 API 接口 URL，免費不限量，參考教程：https://guole.fun/posts/626/',
     'Self-built enterprise WeChat notification API interface URL, free unlimited, refer to the tutorial: https://guole.fun/posts/626/'
   ],
+  [S.ACI + '_DingTalk_WebHook_URL']: [
+    '钉钉 WebHook API 接口 URL，参考教程：',
+    '钉钉 WebHooK API 接口 URL，參考教程：',
+    '钉钉 API 接口 URL，參考教程：',
+    'DingTalk Webhook API interface URL, refer to the tutorial: '
+  ],
   [S.ACI + '_SENDER_EMAIL']: [
     '邮件通知邮箱地址。对于大多数邮箱服务商，SENDER_EMAIL 必须和 SMTP_USER 保持一致，否则无法发送邮件。',
     '郵件通知郵箱地址。對於大多數郵箱服務商，SENDER_EMAIL 必須和 SMTP_USER 保持一致，否則無法發送郵件。',

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -891,6 +891,7 @@ async function sendNotice (comment) {
     noticeWeChat(comment),
     noticePushPlus(comment),
     noticeWeComPush(comment),
+    noticeDingTalkHook(comment),
     noticeQQ(comment)
   ]).catch(console.error)
   return { code: RES_CODE.SUCCESS }
@@ -940,7 +941,8 @@ async function noticeMaster (comment) {
     'SC_SENDKEY',
     'QM_SENDKEY',
     'PUSH_PLUS_TOKEN',
-    'WECOM_API_URL'
+    'WECOM_API_URL',
+    'DingTalk_WebHook_URL'
   ]
   // 判断是否存在即时消息推送配置
   const hasIMPushConfig = IM_PUSH_CONFIGS.some(item => !!config[item])
@@ -1044,6 +1046,22 @@ async function noticeWeComPush (comment) {
   const WeComApiUrl = config.WECOM_API_URL
   const sendResult = await axios.get(WeComApiUrl + WeComApiContent)
   console.log('WinxinPush 通知结果：', sendResult)
+}
+
+// 自定义钉钉WebHook通知
+async function noticeDingTalkHook (comment) {
+  if (!config.DingTalk_WebHook) {
+    console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
+    return
+  }
+  if (config.BLOGGER_EMAIL === comment.mail) return
+  const SITE_URL = config.SITE_URL
+  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
+  const DingTalkApiContent = encodeURIComponent(DingTalkContent)
+  const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
+  const DingTalkApiUrl = config.DingTalk_WebHook
+  const sendResult = await axios.post(DingTalkApiUrl , DingTalkPostBody)
+  console.log('钉钉WebHook 通知结果：', sendResult)
 }
 
 // QQ通知

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -1050,7 +1050,7 @@ async function noticeWeComPush (comment) {
 
 // 自定义钉钉WebHook通知
 async function noticeDingTalkHook (comment) {
-  if (!config.DingTalk_WebHook) {
+  if (!config.DingTalk_WebHook_URL) {
     console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
     return
   }
@@ -1059,8 +1059,8 @@ async function noticeDingTalkHook (comment) {
   const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
   const DingTalkApiContent = encodeURIComponent(DingTalkContent)
   const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
-  const DingTalkApiUrl = config.DingTalk_WebHook
-  const sendResult = await axios.post(DingTalkApiUrl , DingTalkPostBody)
+  const DingTalkApiUrl = config.DingTalk_WebHook_URL
+  const sendResult = await axios.post(DingTalkApiUrl, DingTalkPostBody)
   console.log('钉钉WebHook 通知结果：', sendResult)
 }
 

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -1051,16 +1051,12 @@ async function noticeWeComPush (comment) {
 // 自定义钉钉WebHook通知
 async function noticeDingTalkHook (comment) {
   if (!config.DingTalk_WebHook_URL) {
-    console.log('未配置 DingTalk_WebHook，跳过钉钉WebHook推送')
+    console.log('没有配置 DingTalk_WebHook，放弃钉钉WebHook推送')
     return
   }
   if (config.BLOGGER_EMAIL === comment.mail) return
-  const SITE_URL = config.SITE_URL
-  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + '说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || SITE_URL + comment.url, comment.id)
-  const DingTalkApiContent = encodeURIComponent(DingTalkContent)
-  const DingTalkPostBody = '{"msgtype": "text","text": {"content":"' + DingTalkApiContent + '"}}'
-  const DingTalkApiUrl = config.DingTalk_WebHook_URL
-  const sendResult = await axios.post(DingTalkApiUrl, DingTalkPostBody)
+  const DingTalkContent = config.SITE_NAME + '有新评论啦！🎉🎉' + '\n\n' + '@' + comment.nick + ' 说：' + $(comment.comment).text() + '\n' + 'E-mail: ' + comment.mail + '\n' + 'IP: ' + comment.ip + '\n' + '点此查看完整内容：' + appendHashToUrl(comment.href || config.SITE_URL + comment.url, comment.id)
+  const sendResult = await axios.post(config.DingTalk_WebHook_URL, { msgtype: 'text', text: { content: DingTalkContent } })
   console.log('钉钉WebHook 通知结果：', sendResult)
 }
 

--- a/src/view/components/TkAdminConfig.vue
+++ b/src/view/components/TkAdminConfig.vue
@@ -94,7 +94,7 @@ export default {
             { key: 'QM_SENDKEY', desc: t('ADMIN_CONFIG_ITEM_QM_SENDKEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}k2ni28jkmn72tqdvqryt9827u0o9nbpok`, value: '' },
             { key: 'PUSH_PLUS_TOKEN', desc: t('ADMIN_CONFIG_ITEM_PUSH_PLUS_TOKEN'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}f8ae2b8a107a408b803896a0ec012345`, value: '' },
             { key: 'WECOM_API_URL', desc: t('ADMIN_CONFIG_ITEM_WECOM_API_URL'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://xxx.ap-shanghai.app.tcloudbase.com/自定义api云函数?id=ww***&secert=Ne***&agentId=10***03&msg=`, value: '' },
-            { key: 'DingTalk_WebHook_URL', desc: t('ADMIN_CONFIG_ITEM_DingTalk_WebHook_URL'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://oapi.dingtalk.com/robot/send?access_token=**`, value: '' },
+            { key: 'DingTalk_WebHook_URL', desc: t('ADMIN_CONFIG_ITEM_DingTalk_WebHook_URL'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://oapi.dingtalk.com/robot/send?access_token=***`, value: '' },
             { key: 'SC_MAIL_NOTIFY', desc: t('ADMIN_CONFIG_ITEM_SC_MAIL_NOTIFY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}true`, value: '' }
           ]
         },

--- a/src/view/components/TkAdminConfig.vue
+++ b/src/view/components/TkAdminConfig.vue
@@ -94,6 +94,7 @@ export default {
             { key: 'QM_SENDKEY', desc: t('ADMIN_CONFIG_ITEM_QM_SENDKEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}k2ni28jkmn72tqdvqryt9827u0o9nbpok`, value: '' },
             { key: 'PUSH_PLUS_TOKEN', desc: t('ADMIN_CONFIG_ITEM_PUSH_PLUS_TOKEN'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}f8ae2b8a107a408b803896a0ec012345`, value: '' },
             { key: 'WECOM_API_URL', desc: t('ADMIN_CONFIG_ITEM_WECOM_API_URL'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://xxx.ap-shanghai.app.tcloudbase.com/自定义api云函数?id=ww***&secert=Ne***&agentId=10***03&msg=`, value: '' },
+            { key: 'DingTalk_WebHook_URL', desc: t('ADMIN_CONFIG_ITEM_DingTalk_WebHook_URL'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://oapi.dingtalk.com/robot/send?access_token=**`, value: '' },
             { key: 'SC_MAIL_NOTIFY', desc: t('ADMIN_CONFIG_ITEM_SC_MAIL_NOTIFY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}true`, value: '' }
           ]
         },


### PR DESCRIPTION
>没写过相关语言，基本按 #220 照猫画虎

尝试为Twikoo引入钉钉机器人WebHook消息推送能力

安全认证设置为关键词，避免加签的麻烦

ToDo：

 - [x] get改post
 - [x] 参考 [自定义机器人接入](https://developers.dingtalk.com/document/robots/custom-robot-access) 设定POST Body
 - [x] 测试 

另：#176

> 我好像真的什么都不会，测试环境都没有