### PR TITLE
fix pushplus url

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -188,6 +188,17 @@ twikoo.init({
 
 > 建议使用 CDN 引入 Twikoo 的用户在链接地址上锁定版本，以免将来 Twikoo 升级时受到非兼容性更新的影响。
 
+#### [爆米兔](https://cdn.baomitu.com/) CDN 镜像
+
+请参考爆米兔前端静态资源库 [https://cdn.baomitu.com/twikoo](https://cdn.baomitu.com/twikoo)
+
+引入的 CDN 链接替换为如下即可：
+
+```diff
+- <script src="https://cdn.jsdelivr.net/npm/twikoo@1.4.18/dist/twikoo.all.min.js"></script>
++ <script src="https://lib.baomitu.com/twikoo/1.4.18/twikoo.all.min.js" crossorigin="anonymous" integrity="sha512-czTF7AsBQKM8Udh7f2kYxoEVO6MRUGoBACWgrnURTySkkV+wBwzOiFncA2fjR2JSOJ6vaTGILYIE1laKPH8fKA=="></script>
+```
+
 ## 开启管理面板
 
 1. 进入[环境-登录授权](https://console.cloud.tencent.com/tcb/env/login)，点击“自定义登录”右边的“私钥下载”，下载私钥文件

--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -1021,7 +1021,7 @@ async function noticePushPlus (comment) {
   }
   if (config.BLOGGER_EMAIL === comment.mail) return
   const pushContent = getIMPushContent(comment, { withUrl: false, html: true })
-  const ppApiUrl = 'http://pushplus.hxtrip.com/send'
+  const ppApiUrl = 'http://www.pushplus.plus/send'
   const ppApiParam = {
     token: config.PUSH_PLUS_TOKEN,
     title: pushContent.subject,

--- a/src/js/utils/i18n/i18n.js
+++ b/src/js/utils/i18n/i18n.js
@@ -328,10 +328,10 @@ export default {
     'Notifications for spam comments. Default: true.'
   ],
   [S.ACI + '_PUSH_PLUS_TOKEN']: [
-    '推送加（pushplus.hxtrip.com）推送的 Token',
-    '推送加（pushplus.hxtrip.com）推送的 Token',
-    '推送加（pushplus.hxtrip.com）推送的 Token',
-    'Push+ (pushplus.hxtrip.com) Token.'
+    '推送加（www.pushplus.plus）推送的 Token',
+    '推送加（www.pushplus.plus）推送的 Token',
+    '推送加（www.pushplus.plus）推送的 Token',
+    'Push+ (www.pushplus.plus) Token.'
   ],
   [S.ACI + '_PUSHDEER_KEY']: [
     'PushDeer 推送 key',

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -1032,7 +1032,7 @@ async function noticePushPlus (comment) {
   }
   if (config.BLOGGER_EMAIL === comment.mail) return
   const pushContent = getIMPushContent(comment)
-  const ppApiUrl = 'http://pushplus.hxtrip.com/send'
+  const ppApiUrl = 'http://www.pushplus.plus/send'
   const ppApiParam = {
     token: config.PUSH_PLUS_TOKEN,
     title: pushContent.subject,


### PR DESCRIPTION
修复 Pushplus 的网址。
如果考虑到已经有用户已经配置推送加服务，可以把多个推送加的网址做成可选项供用户选择（没必要