### PR TITLE
fix: 部分ip获取到的数据为一堆占位符

### DIFF
--- a/src/function/twikoo/index.js
+++ b/src/function/twikoo/index.js
@@ -1668,7 +1668,7 @@ async function isAdmin () {
 function getIpRegion ({ ip, detail = false }) {
   if (!ip) return ''
   try {
-    const { region } = ipRegionSearcher.btreeSearchSync(ip)
+    const { region } = ipRegionSearcher.binarySearchSync(ip)
     const [country,, province, city, isp] = region.split('|')
     // 有省显示省，没有省显示国家
     const area = province.trim() ? province : country

--- a/src/vercel/api/index.js
+++ b/src/vercel/api/index.js
@@ -1683,7 +1683,7 @@ async function isAdmin () {
 function getIpRegion ({ ip, detail = false }) {
   if (!ip) return ''
   try {
-    const { region } = ipRegionSearcher.btreeSearchSync(ip)
+    const { region } = ipRegionSearcher.binarySearchSync(ip)
     const [country,, province, city, isp] = region.split('|')
     // 有省显示省，没有省显示国家
     const area = province.trim() ? province : country


### PR DESCRIPTION
如`223.16.3.51`，通过`btreeSearchSync`获取到的内容错误（以下为本地测试结果）：
![image](https://user-images.githubusercontent.com/78738559/168042235-05e1787c-0775-4de4-b749-54a42b5d48da.png)

改用为`binarySearchSync`后正常：
![image](https://user-images.githubusercontent.com/78738559/168042366-e64c2753-3b3b-4de4-8da6-241aa767a8cb.png)

