### PR TITLE
自定义获取请求头IP

### DIFF
--- a/src/server/self-hosted/README.md
+++ b/src/server/self-hosted/README.md
@@ -20,3 +20,4 @@ tkserver
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |
+| `TWIKOO_IP_HEADERS` | 在一些特殊情况下使用，如使用了`CloudFlare CDN` 它会将请求 IP 写到请求头的 `cf-connecting-ip` 字段上，为了能够正确的获取请求 IP 你可以写成 `['headers.cf-connecting-ip']` | `[]` |

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -8,6 +8,7 @@ const { version: VERSION } = require('./package.json')
 const fs = require('fs')
 const path = require('path')
 const Loki = require('lokijs')
+const getUserIP = require('get-user-ip')
 const Lfsa = require('lokijs/src/loki-fs-structured-adapter')
 const { v4: uuidv4 } = require('uuid') // 用户 id 生成
 const {
@@ -892,8 +893,15 @@ async function createCollections () {
   return res
 }
 
-function getIp (request) {
-  return request.headers['x-forwarded-for'] || request.socket.remoteAddress || ''
+function getIp(request) {
+  try {
+    const { TWIKOO_IP_HEADERS } = process.env
+    const headers = TWIKOO_IP_HEADERS ? JSON.parse(TWIKOO_IP_HEADERS) : []
+    return getUserIP(request, headers)
+  } catch (e) {
+    console.error('获取 IP 错误信息：', e)
+  }
+  return getUserIP(request)
 }
 
 function clearRequestTimes () {

--- a/src/server/self-hosted/package.json
+++ b/src/server/self-hosted/package.json
@@ -24,6 +24,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "get-user-ip": "^1.0.1",
     "lokijs": "^1.5.12",
     "twikoo-func": "1.6.7",
     "uuid": "^8.3.2"

--- a/src/server/vercel/package.json
+++ b/src/server/vercel/package.json
@@ -11,6 +11,7 @@
   },
   "homepage": "https://twikoo.js.org",
   "dependencies": {
+    "get-user-ip": "^1.0.1",
     "mongodb": "^3.6.3",
     "twikoo-func": "1.6.7",
     "uuid": "^8.3.2"


### PR DESCRIPTION
在一些特殊情况下使用，如使用了`CloudFlare CDN` 它会将请求 IP 写到请求头的 `cf-connecting-ip` 字段上，为了能够正确的获取请求 IP，新增了一个环境变量，可以决定优先获取指定的 `headers`，具体请看 [get-user-ip](https://www.npmjs.com/package/get-user-ip#%E5%AE%83%E6%98%AF%E5%A6%82%E4%BD%95%E5%B7%A5%E4%BD%9C%E7%9A%84)

