### PR TITLE
i18n & image upload improvements

### DIFF
--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -824,6 +824,12 @@ export default {
     '置頂',
     'Pinned'
   ],
+  COMMENT_FAILED: [
+    '评论失败',
+    '評論失敗',
+    '評論失敗',
+    'Comment failed'
+  ],
   META_INPUT_LINK: [
     '网址',
     '網址',
@@ -901,6 +907,24 @@ export default {
     '發送',
     '傳送',
     'Send'
+  ],
+  IMAGE_UPLOAD_PLACEHOLDER: [
+    '图片上传中',
+    '圖片上傳中',
+    '圖片上傳中',
+    'Uploading image'
+  ],
+  IMAGE_UPLOAD_FAILED: [
+    '图片上传失败',
+    '圖片上傳失敗',
+    '圖片上傳失敗',
+    'IMAGE UPLOAD FAILED'
+  ],
+  IMAGE_UPLOAD_FAILED_NO_CONF: [
+    '博主未配置图床服务',
+    '博主未配置圖床服務',
+    '博主未配置圖床服務',
+    'The blogger didn\'t configured any image bed service'
   ],
   SUBMIT_SENDING: [
     '发送中',

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -926,6 +926,12 @@ export default {
     '博主未配置圖床服務',
     'The blogger didn\'t configured any image bed service'
   ],
+  IMAGE_UPLOAD_PLEASE_WAIT: [
+    '图片上传中，请稍候',
+    '圖片上傳中，請稍候',
+    '圖片上傳中，請稍候',
+    'Uploading image, please wait'
+  ],
   SUBMIT_SENDING: [
     '发送中',
     '發送中',

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -286,13 +286,19 @@ export default {
     },
     async uploadPhotoToThirdParty (fileIndex, fileName, fileType, photo) {
       try {
+        let smmsImageDuplicateCheck
         const { result: uploadResult } = await call(this.$tcb, 'UPLOAD_IMAGE', {
           fileName: `${fileIndex}.${fileType}`,
           photo: await blobToDataURL(photo)
         })
         if (uploadResult.data) {
           this.uploadCompleted(fileIndex, fileName, fileType, uploadResult.data.url)
+        } else if (uploadResult.code == 1040 && uploadResult.err
+          && (smmsImageDuplicateCheck = uploadResult.err.match(/this image exists at: (http[^ ]+)/))) {
+          console.warn(uploadResult)
+          this.uploadCompleted(fileIndex, fileName, fileType, smmsImageDuplicateCheck[1])
         } else {
+          console.error(uploadResult)
           this.uploadFailed(fileIndex, fileType, uploadResult.err)
         }
       } catch (e) {

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -199,7 +199,7 @@ export default {
         }
       } catch (e) {
         logger.error('评论失败', e)
-        this.errorMessage = `评论失败: ${e && e.message}`
+        this.errorMessage = `${t('COMMENT_FAILED')}: ${e && e.message}`
       } finally {
         this.isSending = false
       }
@@ -258,7 +258,7 @@ export default {
       } else if (imageCdn) {
         this.uploadPhotoToThirdParty(fileIndex, fileName, fileType, photo)
       } else {
-        this.uploadFailed(fileIndex, fileType, '未配置图片上传服务')
+        this.uploadFailed(fileIndex, fileType, t('IMAGE_UPLOAD_FAILED_NO_CONF'))
       }
     },
     getUserId () {
@@ -311,7 +311,7 @@ export default {
       this.$refs.inputFile.value = ''
     },
     uploadFailed (fileIndex, fileType, reason) {
-      this.comment = this.comment.replace(this.getImagePlaceholder(fileIndex, fileType), `_上传失败：${reason}_`)
+      this.comment = this.comment.replace(this.getImagePlaceholder(fileIndex, fileType), `_${t('IMAGE_UPLOAD_FAILED')}: ${reason}_`)
       this.$refs.inputFile.value = ''
     },
     paste (text) {
@@ -328,7 +328,7 @@ export default {
       }
     },
     getImagePlaceholder (fileIndex, fileType) {
-      return `![图片上传中${fileIndex}.${fileType}]()`
+      return `![${t('IMAGE_UPLOAD_PLACEHOLDER')} ${fileIndex}.${fileType}]()`
     }
   },
   mounted () {

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -176,6 +176,9 @@ export default {
     async send () {
       this.isSending = true
       try {
+        if (this.comment.match(new RegExp(`!\\[${t('IMAGE_UPLOAD_PLACEHOLDER')}.+\\]\\(\\)`))) {
+          throw new Error(t('IMAGE_UPLOAD_PLEASE_WAIT'))
+        }
         const url = getUrl(this.$twikoo.path)
         const comment = {
           nick: this.nick,


### PR DESCRIPTION
修复上传图片和评论失败等提示未多语言化
图片未完成上传时不允许提交发送
![image](https://user-images.githubusercontent.com/13391795/215050977-b5a85cd4-9324-4fc8-8cf1-a5cdef8d9bbf.png)
当用户多次上传同一图片时，smms可能会返回这个错误，我们可以对其进行处理
![image](https://user-images.githubusercontent.com/13391795/215051122-1423487c-b77c-4e02-9703-2b1b17f5f8f0.png)
