### PR TITLE
fix: get qq anonymous avatar

### DIFF
--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -151,13 +151,11 @@ const fn = {
   async getQQAvatar (qq) {
     try {
       const qqNum = qq.replace(/@qq.com/ig, '')
-      const result = await axios.get(`https://ptlogin2.qq.com/getface?imgtype=4&uin=${qqNum}`)
-      if (result && result.data) {
-        const start = result.data.indexOf('http')
-        const end = result.data.indexOf('"', start)
-        if (start === -1 || end === -1) return null
-        return result.data.substring(start, end)
-      }
+      const result = await axios.get(`https://s.p.qq.com/pub/get_face?img_type=4&uin=${qqNum}`, {
+        maxRedirects: 0,
+        validateStatus: status => [301, 302, 307, 308].includes(status)
+      })
+      return result?.headers?.location || null
     } catch (e) {
       console.error('获取 QQ 头像失败：', e)
     }


### PR DESCRIPTION
## 描述
修复服务端获取QQ匿名头像的问题。

之前使用 #45 中的接口，但目前已经失效。
本 PR 修改了调用的接口。

当配置 `GRAVATAR_CDN` 为 `cravatar.cn` 时此问题不会显现。
因为 [Cravatar](https://cravatar.cn) 支持获取 QQ 头像。